### PR TITLE
Fixed pyglet import

### DIFF
--- a/reiz/audio/_primitives.py
+++ b/reiz/audio/_primitives.py
@@ -4,7 +4,7 @@ Auditory stimuli
 """
 
 import pyglet
-from pyglet.media.sources.procedural import ADSREnvelope, Sine
+from pyglet.media.synthesis import ADSREnvelope, Sine
 import time
 # pyglet.options['audio'] = ('openal', 'pulse', 'directsound', 'silent')
 #%%


### PR DESCRIPTION
Pyglet removed the module pyglet.media.sources and integrated it in pyglet.media.synthesis which broke a import.
changelog indicates thet it was in version 1.0beta1 of pyglet